### PR TITLE
Use multi-stage build for varscan_somatic and vs_mpileup

### DIFF
--- a/DNA/GDC_dna_seq/widgets/GDC_dna_seq/SomaticSniper/Dockerfiles/Dockerfile
+++ b/DNA/GDC_dna_seq/widgets/GDC_dna_seq/SomaticSniper/Dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster-slim AS builder
 RUN apt-get update && apt-get install -y build-essential git-core cmake zlib1g-dev libncurses-dev wget
 RUN wget -c https://github.com/genome/somatic-sniper/archive/v1.0.5.0.tar.gz -O - | tar -xz
-RUN cd somatic-sniper* && cmake . && make deps && make -j && make install && chmod +x /usr/local/bin/bam-somaticsniper
+RUN cd somatic-sniper* && cmake . && make deps && make -j && make install
 
 FROM debian:buster-slim
 MAINTAINER Hong Hung

--- a/DNA/GDC_dna_seq/widgets/GDC_dna_seq/varscan_somatic/Dockerfiles/Dockerfile
+++ b/DNA/GDC_dna_seq/widgets/GDC_dna_seq/varscan_somatic/Dockerfiles/Dockerfile
@@ -2,6 +2,7 @@ FROM adoptopenjdk/openjdk15:jdk-15.0.1_9-alpine
 MAINTAINER Hong Hung
 RUN wget -O VarScan https://sourceforge.net/projects/varscan/files/VarScan.v2.3.9.jar/download
 RUN apk add zlib libbz2 libcurl xz-libs ncurses-dev bash
-COPY samtools /usr/local/bin/samtools
+COPY --from=biodepot/bwa-samtools:gdcalign__alpine_3.12__10034cca \
+    /usr/local/bin/samtools /usr/local/bin/samtools
 COPY run_somatic.sh /usr/local/bin/run_somatic.sh
 COPY run_pileup.sh /usr/local/bin/run_pileup.sh

--- a/DNA/GDC_dna_seq/widgets/GDC_dna_seq/varscan_somatic/Dockerfiles/build.sh
+++ b/DNA/GDC_dna_seq/widgets/GDC_dna_seq/varscan_somatic/Dockerfiles/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-name=$1
-if [ -z $name ]; then
- name=varscan:test
-fi
-docker run --rm -it -v $PWD:/data biodepot/bwa-samtools:gdcalign__alpine_3.12__10034cca cp /usr/local/bin/samtools /data/.
-docker build -t $name .

--- a/DNA/GDC_dna_seq/widgets/GDC_dna_seq/vs_mpileup/Dockerfiles/Dockerfile
+++ b/DNA/GDC_dna_seq/widgets/GDC_dna_seq/vs_mpileup/Dockerfiles/Dockerfile
@@ -2,6 +2,7 @@ FROM adoptopenjdk/openjdk15:jdk-15.0.1_9-alpine
 MAINTAINER Hong Hung
 RUN wget -O VarScan https://sourceforge.net/projects/varscan/files/VarScan.v2.3.9.jar/download
 RUN apk add zlib libbz2 libcurl xz-libs ncurses-dev bash
-COPY samtools /usr/local/bin/samtools
+COPY --from=biodepot/bwa-samtools:gdcalign__alpine_3.12__10034cca \
+    /usr/local/bin/samtools /usr/local/bin/samtools
 COPY run_somatic.sh /usr/local/bin/run_somatic.sh
 COPY run_pileup.sh /usr/local/bin/run_pileup.sh

--- a/DNA/GDC_dna_seq/widgets/GDC_dna_seq/vs_mpileup/Dockerfiles/build.sh
+++ b/DNA/GDC_dna_seq/widgets/GDC_dna_seq/vs_mpileup/Dockerfiles/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-name=$1
-if [ -z $name ]; then
- name=varscan:test
-fi
-docker run --rm -it -v $PWD:/data biodepot/bwa-samtools:gdcalign__alpine_3.12__10034cca cp /usr/local/bin/samtools /data/.
-docker build -t $name .


### PR DESCRIPTION
Updated Dockerfile for varscan_somatic and vs_mpileup to use multi-stage build
to reduce complexity. Removed unnecessary file permission change command in
SomaticSniper Dockerfile.

Signed-off-by: Bob Schmitz III <14095796+rgschmitz1@users.noreply.github.com>